### PR TITLE
Custom errors

### DIFF
--- a/infra/controllers.js
+++ b/infra/controllers.js
@@ -1,0 +1,24 @@
+import { InternalServerError, MethodNotAllowedError } from "@/infra/errors";
+
+function onNoMatchHandler(request, response) {
+  const publicErrorObject = new MethodNotAllowedError();
+  response.status(publicErrorObject.status_code).json(publicErrorObject);
+}
+
+function onErrorHandler(error, request, response) {
+  const publicErrorObject = new InternalServerError({
+    statusCode: error.statusCode,
+    cause: error,
+  });
+
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+const controller = {
+  errorHandlers: {
+    onNoMatch: onNoMatchHandler,
+    onError: onErrorHandler,
+  },
+};
+
+export default controller;

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,4 +1,5 @@
 import { Client } from "pg";
+import { ServiceError } from "./errors";
 
 async function query(queryObject) {
   let client;
@@ -7,9 +8,12 @@ async function query(queryObject) {
     const result = await client.query(queryObject);
     return result;
   } catch (error) {
-    console.log("Error dentro do databse.js");
-    console.error(error);
-    throw error;
+    const serviceErrorObject = new ServiceError({
+      message: "Erro na conexão ou Banco ou na Query.",
+      cause: error,
+    });
+    console.error(serviceErrorObject);
+    throw serviceErrorObject;
   } finally {
     await client?.end();
   }

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,11 +1,31 @@
 export class InternalServerError extends Error {
-  constructor({ cause }) {
+  constructor({ cause, statusCode }) {
     super("Um erro interno não esperado aconteceu.", {
       cause,
     });
     this.name = "InternalServerError";
     this.action = "Entre em contato com suporte.";
-    this.statusCode = 500;
+    this.statusCode = statusCode || 500;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class ServiceError extends Error {
+  constructor({ message, cause }) {
+    super(message || "Serviço indisponível no momento.", {
+      cause,
+    });
+    this.name = "ServiceError";
+    this.action = "Verifique se o serviço está disponível.";
+    this.statusCode = 503;
   }
 
   toJSON() {

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -10,12 +10,29 @@ export class InternalServerError extends Error {
 
   toJSON() {
     return {
-      error: {
-        name: this.name,
-        message: this.message,
-        action: this.action,
-        status_code: this.statusCode,
-      },
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class MethodNotAllowedError extends Error {
+  constructor() {
+    super("Método não permitido para este endpoint");
+    this.name = "MethodNotAllowedError";
+    this.action =
+      "Verifique se o método HTTP enviado é válido para este endpoint";
+    this.status_code = 405;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.status_code,
     };
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "eslint": "8.57.0",
         "eslint-config-next": "15.1.6",
         "next": "15.1.6",
+        "next-connect": "^1.0.0",
         "node-pg-migrate": "7.9.0",
         "pg": "8.13.1",
         "postcss": "^8.5.1",
@@ -2759,6 +2760,12 @@
       "dependencies": {
         "@textlint/ast-node-types": "^14.4.2"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -8666,6 +8673,19 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -9865,6 +9885,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint": "8.57.0",
     "eslint-config-next": "15.1.6",
     "next": "15.1.6",
+    "next-connect": "^1.0.0",
     "node-pg-migrate": "7.9.0",
     "pg": "8.13.1",
     "postcss": "^8.5.1",

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -2,30 +2,12 @@ import { createRouter } from "next-connect";
 import migrationRunner from "node-pg-migrate";
 import { resolve } from "node:path";
 import database from "infra/database";
-import { InternalServerError, MethodNotAllowedError } from "@/infra/errors";
-
+import controller from "@/infra/controllers";
 const router = createRouter();
 
 router.get(getHandler).post(postHandler);
 
-export default router.handler({
-  onNoMatch: onNoMatchHandler,
-  onError: onErrorHandler,
-});
-
-async function onNoMatchHandler(request, response) {
-  const publicErrorObject = new MethodNotAllowedError();
-  response.status(publicErrorObject.status_code).json(publicErrorObject);
-}
-
-function onErrorHandler(error, request, response) {
-  const publicErrorObject = new InternalServerError({
-    cause: error,
-  });
-
-  console.error("\nErro dentro do catch do next-connect:", error);
-  response.status(500).json(publicErrorObject);
-}
+export default router.handler(controller.errorHandlers);
 
 function getMigrationOptions(dbClient, dryRun = true) {
   return {

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,49 +1,71 @@
+import { createRouter } from "next-connect";
 import migrationRunner from "node-pg-migrate";
 import { resolve } from "node:path";
 import database from "infra/database";
-export default async function migrations(request, response) {
-  const allowedMethods = ["GET", "POST"];
+import { InternalServerError, MethodNotAllowedError } from "@/infra/errors";
 
-  if (!allowedMethods.includes(request.method)) {
-    response.status(405).json({
-      error: `Method "${request.method}" Not Allowed`,
-    });
-    return;
-  }
+const router = createRouter();
 
+router.get(getHandler).post(postHandler);
+
+export default router.handler({
+  onNoMatch: onNoMatchHandler,
+  onError: onErrorHandler,
+});
+
+async function onNoMatchHandler(request, response) {
+  const publicErrorObject = new MethodNotAllowedError();
+  response.status(publicErrorObject.status_code).json(publicErrorObject);
+}
+
+function onErrorHandler(error, request, response) {
+  const publicErrorObject = new InternalServerError({
+    cause: error,
+  });
+
+  console.error("\nErro dentro do catch do next-connect:", error);
+  response.status(500).json(publicErrorObject);
+}
+
+function getMigrationOptions(dbClient, dryRun = true) {
+  return {
+    dbClient,
+    dryRun,
+    dir: resolve("infra", "migrations"),
+    direction: "up",
+    verbose: true,
+    migrationsTable: "pgmigrations",
+  };
+}
+
+async function withDatabaseClient(handler) {
   let dbClient;
-
   try {
     dbClient = await database.getNewClient();
-    const migrationsDefaultOptions = {
-      dbClient: dbClient,
-      dryRun: true,
-      dir: resolve("infra", "migrations"),
-      direction: "up",
-      verbose: true,
-      migrationsTable: "pgmigrations",
-    };
-
-    if (request.method === "GET") {
-      const pendingMigrations = await migrationRunner(migrationsDefaultOptions);
-      response.status(200).json(pendingMigrations);
-    }
-
-    if (request.method === "POST") {
-      const migratedMigrations = await migrationRunner({
-        ...migrationsDefaultOptions,
-        dryRun: false,
-      });
-
-      if (migratedMigrations.length > 0) {
-        response.status(201).json(migratedMigrations);
-      }
-      response.status(200).json(migratedMigrations);
-    }
-  } catch (error) {
-    console.log(error);
-    throw error;
+    return await handler(dbClient);
   } finally {
-    await dbClient.end();
+    if (dbClient) {
+      await dbClient?.end();
+    }
   }
+}
+
+async function getHandler(request, response) {
+  await withDatabaseClient(async (dbClient) => {
+    const pendingMigrations = await migrationRunner(
+      getMigrationOptions(dbClient),
+    );
+    response.status(200).json(pendingMigrations);
+  });
+}
+
+async function postHandler(request, response) {
+  await withDatabaseClient(async (dbClient) => {
+    const migratedMigrations = await migrationRunner({
+      ...getMigrationOptions(dbClient, false),
+    });
+
+    const statusCode = migratedMigrations.length > 0 ? 201 : 200;
+    response.status(statusCode).json(migratedMigrations);
+  });
 }

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,39 +1,58 @@
-import { InternalServerError } from "@/infra/errors";
+import { createRouter } from "next-connect";
+import { InternalServerError, MethodNotAllowedError } from "@/infra/errors";
 import database from "infra/database";
 
-export default async function status(request, response) {
-  try {
-    const updateAt = new Date().toISOString();
+const router = createRouter();
 
-    const databaseVersion = await database.query("SHOW server_version;");
-    const databaseVersionValue = databaseVersion.rows[0];
+router.get(getHandler);
 
-    const maxConnections = await database.query("SHOW max_connections;");
-    const maxConnectionsValue = await maxConnections.rows[0];
+export default router.handler({
+  onNoMatch: onNonMatchHandler,
+  onError: onErrorHandler,
+});
 
-    const databaseName = process.env.POSTGRES_DB;
+function onNonMatchHandler(request, response) {
+  const publicErrorObject = new MethodNotAllowedError();
 
-    const openedConnections = await database.query({
-      text: "SELECT count(*)::int FROM pg_stat_activity WHERE datname = $1;",
-      values: [databaseName],
-    });
-    const openedConnectionsValue = await openedConnections.rows[0];
+  response.status(publicErrorObject.status_code).json(publicErrorObject);
+}
 
-    response.status(200).json({
-      updated_at: updateAt,
-      dependencies: {
-        database: {
-          version: databaseVersionValue.server_version,
-          max_connections: parseInt(maxConnectionsValue.max_connections),
-          opened_connections: openedConnectionsValue.count,
-        },
+function onErrorHandler(error, request, response) {
+  const publicErrorObject = new InternalServerError({
+    cause: error,
+  });
+
+  console.log("\nErro dentro do catch do next-connect.");
+  console.log(error);
+
+  response.status(500).json(publicErrorObject);
+}
+
+async function getHandler(request, response) {
+  const updateAt = new Date().toISOString();
+
+  const databaseVersion = await database.query("SHOW server_version;");
+  const databaseVersionValue = databaseVersion.rows[0];
+
+  const maxConnections = await database.query("SHOW max_connections;");
+  const maxConnectionsValue = await maxConnections.rows[0];
+
+  const databaseName = process.env.POSTGRES_DB;
+
+  const openedConnections = await database.query({
+    text: "SELECT count(*)::int FROM pg_stat_activity WHERE datname = $1;",
+    values: [databaseName],
+  });
+  const openedConnectionsValue = await openedConnections.rows[0];
+
+  response.status(200).json({
+    updated_at: updateAt,
+    dependencies: {
+      database: {
+        version: databaseVersionValue.server_version,
+        max_connections: parseInt(maxConnectionsValue.max_connections),
+        opened_connections: openedConnectionsValue.count,
       },
-    });
-  } catch (error) {
-    const publicErrorObject = new InternalServerError({
-      cause: error,
-    });
-    console.error(publicErrorObject);
-    response.status(500).json(publicErrorObject);
-  }
+    },
+  });
 }

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,32 +1,12 @@
 import { createRouter } from "next-connect";
-import { InternalServerError, MethodNotAllowedError } from "@/infra/errors";
 import database from "infra/database";
+import controller from "@/infra/controllers";
 
 const router = createRouter();
 
 router.get(getHandler);
 
-export default router.handler({
-  onNoMatch: onNonMatchHandler,
-  onError: onErrorHandler,
-});
-
-function onNonMatchHandler(request, response) {
-  const publicErrorObject = new MethodNotAllowedError();
-
-  response.status(publicErrorObject.status_code).json(publicErrorObject);
-}
-
-function onErrorHandler(error, request, response) {
-  const publicErrorObject = new InternalServerError({
-    cause: error,
-  });
-
-  console.log("\nErro dentro do catch do next-connect.");
-  console.log(error);
-
-  response.status(500).json(publicErrorObject);
-}
+export default router.handler(controller.errorHandlers);
 
 async function getHandler(request, response) {
   const updateAt = new Date().toISOString();

--- a/tests/integration/api/v1/migrations/delete.test.js
+++ b/tests/integration/api/v1/migrations/delete.test.js
@@ -1,0 +1,30 @@
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitingForAllServices();
+  await orchestrator.clearDatabase();
+});
+
+describe("DELETE api/v1/migrations", () => {
+  describe("Anonymous user", () => {
+    test("Only accept GET and POST", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/migrations", {
+        method: "DELETE",
+        headers: {
+          "Content-type": "application/json",
+        },
+      });
+      expect(response.status).toBe(405);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        action:
+          "Verifique se o método HTTP enviado é válido para este endpoint",
+        message: "Método não permitido para este endpoint",
+        name: "MethodNotAllowedError",
+        status_code: 405,
+      });
+    });
+  });
+});

--- a/tests/integration/api/v1/migrations/post.test.js
+++ b/tests/integration/api/v1/migrations/post.test.js
@@ -45,17 +45,3 @@ describe("POST /api/v1/migrations", () => {
     });
   });
 });
-
-describe("DELETE api/v1/migrations", () => {
-  describe("Anonymous user", () => {
-    test("Only accept GET and POST", async () => {
-      const response = await fetch("http://localhost:3000/api/v1/migrations", {
-        method: "DELETE",
-        headers: {
-          "Content-type": "application/json",
-        },
-      });
-      expect(response.status).toBe(405);
-    });
-  });
-});

--- a/tests/integration/api/v1/status/post.test.js
+++ b/tests/integration/api/v1/status/post.test.js
@@ -1,0 +1,26 @@
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitingForAllServices();
+});
+
+describe("POST /api/v1/status", () => {
+  describe("Anonymous user", () => {
+    test("Retrieving current system status", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/status", {
+        method: "POST",
+      });
+      expect(response.status).toBe(405);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método não permitido para este endpoint",
+        action:
+          "Verifique se o método HTTP enviado é válido para este endpoint",
+        status_code: 405,
+      });
+    });
+  });
+});


### PR DESCRIPTION
1. Install `next-connect`
2. Standardizes the controllers with `next-connect` in `/api/v1/status` and `/api/v1/migrations`
3. Now the `InternalServerError` accept injections of `statusCode`
